### PR TITLE
`SimCollect()`/`aggregate_simulations()` Does Not Account for Warnings

### DIFF
--- a/R/SimCollect.R
+++ b/R/SimCollect.R
@@ -215,6 +215,7 @@ SimCollect <- function(files = NULL, filename = NULL,
         as.data.frame(x[ ,grepl('ERROR', colnames(x)), drop=FALSE]))
     nms <- unique(do.call(c, lapply(errors, function(x) colnames(x))))
     readin <- lapply(readin, function(x) x[ ,!grepl('ERROR', colnames(x)), drop=FALSE])
+    readin <-lapply(readin, function(x) x[,!grepl('WARNINGS', colnames(x)), drop = FALSE]) # FIXME: Check for compatibility!
     if(length(unique(sapply(readin, ncol))) > 1L)
         stop('Number of columns in the replications not equal')
     designs <- lapply(readin, \(x) SimExtract(x, 'Design'))
@@ -295,7 +296,7 @@ SimCollect <- function(files = NULL, filename = NULL,
             out$MISSED_REPLICATIONS <- as.integer(diff)
             out$TARGET_REPLICATIONS <- as.integer(target.reps)
             out$REPLICATIONS <- NULL
-            message("The follow design conditions did not satisfy the target.reps")
+            message("The following design conditions did not satisfy the target.reps")
             return(out[reps_bad,])
         } else {
             message(c('All replications satisfied target.reps criteria of ', target.reps))


### PR DESCRIPTION
Side steps the warning problem for aggregating results, but it may be the case that warnings are now entirely removed from the resulting tibble. 