### PR TITLE
Fix SimCheck Behavior

### DIFF
--- a/R/SimCheck.R
+++ b/R/SimCheck.R
@@ -74,7 +74,7 @@ SimCheck <- function(dir = NULL, files = NULL, min = 1L, max = NULL){
         warning(sprintf('The following row conditions have nothing saved:\n%s\n',
                         paste0(ret$Empty_Row_Conditions, collapse=',')))
     }
-    if(any(notin) || any(!nonzero)){
+    if(any(notin) || any(empty_file)){
         ret$Empty_Missing_Row_Conditions <- c(minmax[notin], minmax[empty_file]) |>
             unique() |>
             sort()


### PR DESCRIPTION
There used to be false alarms `nonzero` was a different length from `notin`.

Also, `nonzero` is a named vector, whereas `notin` is a logical vector, which would create strange behavior. 

So I thought that with a few small changes that things might be clearer. I also returned different kinds of things.