### PR TITLE
Enable progress bars in non-interactive mode for SLURM clusters

### DIFF
--- a/R/analysis.R
+++ b/R/analysis.R
@@ -10,6 +10,13 @@ Analysis <- function(Functions, condition, replications, fixed_objects, cl, MPI,
 {
     # This defines the work-flow for the Monte Carlo simulation given the condition (row in Design)
     #  and number of replications desired
+
+    # Configure pbapply for non-interactive mode (e.g., SLURM cluster logs)
+    if(progress && !interactive()) {
+        old_pboptions <- pbapply::pboptions(type = "txt", char = "=", style = 3)
+        on.exit(pbapply::pboptions(old_pboptions), add = TRUE)
+    }
+
     used_mainsim <- if(is.finite(max_time)) mainsim_maxtime else mainsim
     if(useFuture){
         if(!is.null(seed)) set_seed(seed[condition$ID])

--- a/R/runSimulation.R
+++ b/R/runSimulation.R
@@ -600,7 +600,9 @@
 #'   range 1 to 2147483647 for each condition via \code{\link{genSeeds}}
 #'
 #' @param progress logical; display a progress bar (using the \code{pbapply} package)
-#'   for each simulation condition?
+#'   for each simulation condition? In interactive sessions, shows a timer-based
+#'   progress bar. In non-interactive sessions (e.g., HPC cluster jobs), displays
+#'   text-based progress updates that are visible in log files.
 #'   This is useful when simulations conditions take a long time to run (see also the
 #'   \code{notification} argument). Default is \code{TRUE}
 #'


### PR DESCRIPTION
Configure pbapply to display text-based progress bars when running
in non-interactive mode (e.g., batch jobs, Rscript). Previously,
progress tracking was disabled in non-interactive sessions, making
it impossible to monitor simulation progress in SLURM log files.

Changes:
- R/analysis.R: Add pboptions configuration to force type="txt"
  in non-interactive mode while preserving timer bars in interactive
  sessions
- R/runSimulation.R: Update progress parameter documentation to
  describe the new behavior

Interactive users see no change. Non-interactive users (SLURM, batch
jobs) now see text progress bars when monitoring logs via tail -f.

Fixes #75