### PR TITLE
Fix bug in `PK_average()`

### DIFF
--- a/R/RobbinsMonro.R
+++ b/R/RobbinsMonro.R
@@ -154,8 +154,7 @@ RobbinsMonro <- function(f, p, ...,
 }
 
 PK_average <- function(history){
-    t <- sum(rowSums(!is.na(history)) > 0L)
-    ret <- colSums(history[1:(t - 1L), , drop=FALSE], na.rm=TRUE) / t
+    ret <- colMeans(history, na.rm=TRUE)
     matrix(ret, ncol=ncol(history))
 }
 

--- a/tests/tests/test-06-robbins-monro.R
+++ b/tests/tests/test-06-robbins-monro.R
@@ -1,0 +1,13 @@
+context('RobbinsMonro')
+
+test_that('RobbinsMonro (Polyak-Juditsky)', {
+
+  .f <- \(x) x - mean(rnorm(10000, mean = pi, sd = 0.5))
+
+  rm <- RobbinsMonro(f = .f,
+                     p = 2.1, # initial guess
+                     Polyak_Juditsky = TRUE,
+                     tol = 0.001)
+
+  expect_equal(c(rm$root), mean(rm$history))
+})


### PR DESCRIPTION
This is a proposed fix to #87. With the updated function written as

```r
PK_average <- function(history){
    ret <- colMeans(history, na.rm=TRUE)
    matrix(ret, ncol=ncol(history))
}
```

I've also added a test case asserting that `<RM-object>$root` should be the same as `colMeans(<RM-object>$history)`

```r
.f <- \(x) x - mean(rnorm(10000, mean = pi, sd = 0.5))

rm <- RobbinsMonro(f = .f,
                   p = 2.1, # initial guess
                   Polyak_Juditsky = TRUE,
                   tol = 0.001)

expect_equal(c(rm$root), mean(rm$history))
```

I realize that the test case doesn't really fit in with the current structure of  `tests/tests/`, so it could perhaps be moved elsewhere, or removed entirely.

Again, if I'm the one who has misunderstood something here, and `PK_average()` is fine as is, please just reject the PR.

Best,
Kjell

