### PR TITLE
Fix serial-path reproducibility for L'Ecuyer-CMRG (list) seeds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Changes in SimDesign 2.25
 
+- Fixed a bug where list-based (L'Ecuyer-CMRG) seeds were not applied on the
+  serial (non-parallel) execution path, causing `runArraySimulation(..., iseed)`
+  and `runSimulation(seed = <genSeeds() list>)` to be non-reproducible when
+  `parallel = FALSE`. The internal `set_seed()` helper was assigning
+  `.Random.seed` to its local frame rather than `.GlobalEnv`, so the RNG state
+  was silently discarded. The parallel path was unaffected
+
 - `SimErrors()` and `SimWarnings()`  functions added to better track and 
   extract error/warning information. Makes it easier to track down specific 
   seed states to replicate any of the recorded messages

--- a/R/util.R
+++ b/R/util.R
@@ -678,7 +678,7 @@ pickReps <- function(replications, iter){
 }
 
 set_seed <- function(seed){
-    if(is.list(seed)) .Random.seed <- seed[[1L]]
+    if(is.list(seed)) .GlobalEnv$.Random.seed <- seed[[1L]]
     else set.seed(seed)
     invisible(NULL)
 }

--- a/tests/tests/test-03-array.R
+++ b/tests/tests/test-03-array.R
@@ -70,6 +70,22 @@ test_that('array', {
 
     SimClean('mysim-1.rds')
 
+    # serial iseed must be byte-for-byte reproducible (L'Ecuyer-CMRG seed
+    # applied via set_seed(); see GitHub bug re: .GlobalEnv assignment)
+    res_s1 <- runArraySimulation(design=Design, replications=20,
+                                 generate=Generate, analyse=Analyse,
+                                 summarise=Summarise, arrayID=1L,
+                                 iseed=iseed, filename='serialseed',
+                                 parallel=FALSE, verbose=FALSE)
+    res_s2 <- runArraySimulation(design=Design, replications=20,
+                                 generate=Generate, analyse=Analyse,
+                                 summarise=Summarise, arrayID=1L,
+                                 iseed=iseed, filename='serialseed',
+                                 parallel=FALSE, verbose=FALSE)
+    expect_identical(SimExtract(res_s1, what='results'),
+                     SimExtract(res_s2, what='results'))
+    SimClean('serialseed-1.rds')
+
     ########################
     # Same submission job as above, however split the replications over multiple
     # evaluations and combine when complete


### PR DESCRIPTION
## Summary

`set_seed()` did not actually apply list-type (L'Ecuyer-CMRG) seeds on the **serial** (non-parallel) execution path, so seeded runs were not reproducible when `parallel = FALSE`.

The helper assigned the seed to its **local function frame**:

```r
set_seed <- function(seed){
    if(is.list(seed)) .Random.seed <- seed[[1L]]   # local binding -> discarded on return
    else set.seed(seed)
    invisible(NULL)
}
```

R's RNG only ever consults `globalenv()$.Random.seed`, so this assignment had no effect and the L'Ecuyer-CMRG state was silently dropped. The serial loop then ran off the ambient global RNG state.

This affected:

- `runArraySimulation(..., iseed = <int>, parallel = FALSE)` — `genSeeds()` produces a length-1 list holding a 7-integer L'Ecuyer state, which was dropped.
- `runSimulation(seed = genSeeds(design, iseed = ...), parallel = FALSE)` — same list-seed path.

The **parallel** path was unaffected, because it installs the seed via `clusterSetRNGSubStream()` / `clusterSetRNGStream()`, which `assign()` into the workers' `.GlobalEnv`.

## Fix

One-line change: assign into `.GlobalEnv` (matching the idiom already used at `analysis.R:21` and `util.R:711`):

```r
if(is.list(seed)) .GlobalEnv$.Random.seed <- seed[[1L]]
```

Setting a valid L'Ecuyer-CMRG vector as the global `.Random.seed` also switches the active generator automatically, since R derives the RNG kind from `.Random.seed[1]`. No explicit `RNGkind()` call is needed (the array path already sets it).

## Verification

Before the fix, two serial runs with the same `iseed` produced different per-replication draws; after the fix they are byte-identical (and parallel runs remain reproducible as before):

| Mode | Before | After |
|---|---|---|
| `parallel = FALSE` | not reproducible | **reproducible** |
| `parallel = TRUE`  | reproducible | reproducible |

A regression test asserting serial-path reproducibility of `runArraySimulation(..., iseed, parallel = FALSE)` is added to `tests/tests/test-03-array.R`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)